### PR TITLE
more general use by not requiring esp for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ authors = ["José Morales <josfemova@gmail.com>"]
 [dependencies]
 embedded-io-async = "0.6"
 defmt = "0.3"
-embassy-time = "0.3"
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "cd4e199065bef50637d61622318c6dd1b5443f9f"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,8 @@ authors = ["José Morales <josfemova@gmail.com>"]
 
 [dependencies]
 embedded-io-async = "0.6"
-embassy-time = "0.3"
-esp-println = {version = "0.9.1",features = ["esp32c3", "log"]}
+embassy-time = { git = "https://github.com/embassy-rs/embassy", features = [
+    "defmt",
+    "defmt-timestamp-uptime",
+] }
+defmt = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["José Morales <josfemova@gmail.com>"]
 
 [dependencies]
 embedded-io-async = "0.6"
-embassy-time = { version = "0.3.2", features = [
+embassy-time = { version = "0.3", features = [
     "defmt",
     "defmt-timestamp-uptime",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["José Morales <josfemova@gmail.com>"]
 
 [dependencies]
 embedded-io-async = "0.6"
-embassy-time = { git = "https://github.com/embassy-rs/embassy", features = [
+embassy-time = { version = "0.3.2", features = [
     "defmt",
     "defmt-timestamp-uptime",
 ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,8 +440,8 @@ where
         if self.feedback_enable && (command_data.command != Command::Reset) {
             if self.last_cmd_acknowledged != true {
                 info!("wut {:?} {:?}",
-                    self.last_command,
-                    self.last_response);
+                    Debug2Format(&self.last_command),
+                    Debug2Format(&self.last_response));
                 Err(Error::FailedAck)
             } else {
                 Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,11 +439,9 @@ where
         
         if self.feedback_enable && (command_data.command != Command::Reset) {
             if self.last_cmd_acknowledged != true {
-                esp_println::println!(
-                    "wut {:02X?} {:02X?}",
+                info!("wut {:?} {:?}",
                     self.last_command,
-                    self.last_response
-                );
+                    self.last_response);
                 Err(Error::FailedAck)
             } else {
                 Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 use embassy_time::{Duration, Instant, Timer};
 use embedded_io_async::{Read, ReadReady, Write};
+use defmt::*;
 
 const START_BYTE: u8 = 0x7E;
 const END_BYTE: u8 = 0xEF;
@@ -247,7 +248,7 @@ where
                             }
                         }
                         INDEX_END_BYTE => {
-                            esp_println::println!("{:X?}", &self.last_command);
+                            info!("Received message: {:?}", &message);
                             if byte != END_BYTE {
                                 current_index = 0;
                             } else {
@@ -329,7 +330,7 @@ where
         let checksum = checksum(&out_buffer[INDEX_VERSION..INDEX_CHECKSUM_H]);
         out_buffer[INDEX_CHECKSUM_H] = (checksum >> 8) as u8;
         out_buffer[INDEX_CHECKSUM_L] = checksum as u8;
-        esp_println::println!("{:X?}", out_buffer);
+        info!("Sending command: {:?}", out_buffer);
         self.port
             .write_all(&out_buffer)
             .await


### PR DESCRIPTION
Hi, first of all many thanks for this driver, it works very well for me. 
I forked and made changes for my needs a little while ago. But since embassy released things just today I no longer need a git dependency on embassy in this driver AND I was hoping you would consider switching to `info!` macro for logging, then I would no longer need my fork :-)